### PR TITLE
Serve static files to client and handle unknown paths.

### DIFF
--- a/server/MineSweeper_Project/settings.py
+++ b/server/MineSweeper_Project/settings.py
@@ -53,11 +53,10 @@ MIDDLEWARE = [
 ]
 
 ROOT_URLCONF = 'MineSweeper_Project.urls'
-
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [os.path.join(BASE_DIR, '../build/'),],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -133,7 +132,15 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
-LOGIN_REDIRECT_URL = ''
+# We do this so that django's collectstatic copies or our bundles to
+# the STATIC_ROOT or syncs them to whatever storage we use.
+STATICFILES_DIRS = (
+    os.path.join(BASE_DIR, '../build'), 
+)
+
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+
+LOGIN_REDIRECT_URL = '/compete'
 LOGIN_ERROR_URL = '/login-error/'
 
 # Fetching the client ID and secret Key required for Open Authentication.

--- a/server/MineSweeper_Project/urls.py
+++ b/server/MineSweeper_Project/urls.py
@@ -22,4 +22,5 @@ urlpatterns = [
     url(r'^users/$', views.userInfo, name='users'),
     url(r'^admin/', include(admin.site.urls)),
     url(r'', include('social_django.urls', namespace='social')),
+    url(r'^(?P<path>.*)$', views.redirectUnknownPaths, name='redirectUnknownPaths'),
 ]

--- a/server/app/views.py
+++ b/server/app/views.py
@@ -1,28 +1,24 @@
 from django.shortcuts import render
-from django.template.context import RequestContext
 from django.contrib.auth.models import User
 from django.http import JsonResponse
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth import authenticate
 from models import WinRecord
-# import json
-# import jsonpickle
+from django.shortcuts import redirect
+from django.http import HttpResponseRedirect
+from django.contrib.staticfiles.templatetags.staticfiles import static
 
+# Handles unkown paths and redirect it to the valid paths.
+def redirectUnknownPaths(request, path):
+	if 'res' in path or 'bundle' in path:
+		# Composing path for static files.
+		url = static(path)
+		return HttpResponseRedirect(url)
+	# If not static files then we serve index.html for all unkown URL	
+	return render(request, 'index.html',
+		context = {'user': request.user,})
 
 def home(request):
-	# print "User Model : " + str(User.objects.all())
-	# users = User.objects.all() 
-	# for user in users:
-	# 	print user.password
-	# log_user = request.user
-	# if not log_user.is_anonymous: 
-	# 	print "Username: " + log_user.username
-	# 	print "password: " + log_user.password
-	# 	print "email: " + log_user.email
-	# 	print "first_name: " + log_user.first_name
-	# 	print "Last_name: " + log_user.last_name
-
-	return render(request, 'home.html',
+	return render(request, 'index.html',
                  context = {'user': request.user,})
 
 @login_required(login_url='/login/google-oauth2/')
@@ -39,28 +35,4 @@ def userInfo(request):
 				value = getattr(winrecord, name)
 				Response[name] = str(value)
 		Response_array.append(Response)
-
-	print Response_array
-	# def expected_data(obj):
-	# 	obj_dict = {}
-	# 	obj_dict['user'] = obj['_user_cache']
-	# 	obj_dict['level'] = obj['level']
-	# 	obj_dict['time'] = obj['time']
-	# 	return obj_dict
-	
-	# def obj_dict(obj):
-	# 	if hasattr(obj, '__dict__'):
-	# 		print obj.__dict__
-	# 		# return expected_data(obj.__dict__)
-	# 		return obj.__dict__
-		
-	
-	# json_string = ''
-	# a = []
-	# # for winrecord in winrecords:
-	# 	# a.append(obj_dict(winrecord.)) 
-	# 	# json_string +=json.dumps(winrecord, default=obj_dict)
-
-	# 	# print json.dumps(vars(winrecord),sort_keys=True, indent=4)
-	# print a
 	return JsonResponse({'Response' : Response_array})


### PR DESCRIPTION
Fix :
  1. Serve static files :
       In django, static files are provided from "/static/" location or
       static files are referred from STATIC_URL defined in settings.py
       In our case, we are trying to fetch static files by their relative
       path i.e without prefixing the static location to files path.
       To fix this issue, we have handle those relatives path and redirect
       them to valid static files path in function "redirectUnknownPaths".

  2. Handle unknown paths :
       We serve index.html for all unknown or unregistered requests. While
       serving index.html to request, we assures that current request is
       not for static resources.